### PR TITLE
Improve finished logic

### DIFF
--- a/swmr_tools/__init__.py
+++ b/swmr_tools/__init__.py
@@ -1,5 +1,12 @@
 from .keyfollower import KeyFollower, RowKeyFollower
 from .datasource import DataSource
 from . import utils
+import importlib.metadata
 
 __all__ = ["KeyFollower", "RowKeyFollower", "DataSource", "utils"]
+
+try:
+    # __package__ allows for the case where __name__ is "__main__"
+    __version__ = importlib.metadata.version(__package__ or __name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"

--- a/swmr_tools/keyfollower.py
+++ b/swmr_tools/keyfollower.py
@@ -204,7 +204,7 @@ class KeyFollower:
         f = self.h5file[self.finished_dataset]
         f.refresh()
 
-        finished = f[0] == 1
+        finished = not f[0] == 0
 
         if self._prelim_finished_check and finished:
             return True

--- a/swmr_tools/keyfollower.py
+++ b/swmr_tools/keyfollower.py
@@ -61,7 +61,6 @@ class KeyFollower:
         self._finish_tag = False
         self._check_successful = False
         self.scan_rank = -1
-        self._prelim_finished_check = False
         self.maxshape = None
 
     def __iter__(self):
@@ -141,7 +140,6 @@ class KeyFollower:
         """Reset the iterator to start again from index 0"""
         self.current_key = -1
         self._finish_tag = False
-        self._prelim_finished_check = False
 
     def _timer_reset(self):
         # Hidden method, restarts timer for timeout method
@@ -204,18 +202,15 @@ class KeyFollower:
         f = self.h5file[self.finished_dataset]
         f.refresh()
 
-        finished = not f[0] == 0
+        if f.size != 1:
 
-        if self._prelim_finished_check and finished:
-            return True
+            logger.warning(
+                f"finished dataset ({self.finished_dataset}) is non-singular"
+            )
+            return False
 
-        # go through the timeout loop once more
-        # in case finish is flushed slightly before
-        # the last of the keys
-        if finished:
-            self._prelim_finished_check = True
-
-        return False
+        # returning True means we're finished
+        return not f[0] == 0
 
     def is_finished(self):
         """Returns True if the KeyFollower instance has completed its iteration"""

--- a/tests/test_KeyFollower.py
+++ b/tests/test_KeyFollower.py
@@ -1,5 +1,6 @@
 from swmr_tools import KeyFollower
 import utils
+import numpy as np
 
 
 def test_first_frame():
@@ -276,6 +277,31 @@ def test_multiple_keys_from_node():
     for key in kf:
         current_key += 1
     assert current_key == 25
+
+
+def test_finished_dataset():
+
+    data = "data"
+    finished = "finished"
+    key_paths = [data]
+
+    mds = utils.make_mock()
+    mds.dataset = mds.dataset + 1
+    mfds = utils.make_mock(shape=[1])
+    mfds.dataset = np.array([0])
+    f = {data: mds, finished: mfds}
+    kf = KeyFollower(f, key_paths, timeout=0.1, finished_dataset=finished)
+    assert not kf.is_finished()
+
+    mfds.dataset = np.array([1])
+    assert kf.is_finished()
+
+    # can't have a finished array with more than one element
+    mfds = utils.make_mock(shape=[4])
+    mfds.dataset = mfds.dataset + 1
+    f = {data: mds, finished: mfds}
+    kf = KeyFollower(f, key_paths, timeout=0.1, finished_dataset=finished)
+    assert not kf.is_finished()
 
 
 # Test and Feature to be added

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,6 @@ def make_mock(shape=[5, 10, 1, 1], maxshape=None):
 
     mds = Mock()
     mds.dataset = np.zeros(shape)
-    mds.refresh = lambda: print("Refresh")
 
     if maxshape is None:
         mds.maxshape = shape

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,4 +17,6 @@ def make_mock(shape=[5, 10, 1, 1], maxshape=None):
         return mds.dataset[value]
 
     mds.__getitem__ = Mock(side_effect=slicemock)
+
+    mds.size = mds.dataset.size
     return mds


### PR DESCRIPTION
- fix the the fact that `== 1 != not == 0`
- remove unnecessary `.refresh()` method from mocked dataset
- add a size to mocked to dataset so one can get the size of a mocked dataset
- add test for finished_dataset
- remove `_prelim_finished_check` from `kf._check_finished_dataset()` logic chain. Previously, one needed to call `_check_finished_dataset()` _twice_ once the file was finished.
- add a package version using importlib to get at pip tagged version